### PR TITLE
Dedicated mode now default and baseline results download

### DIFF
--- a/docs/support-guide.md
+++ b/docs/support-guide.md
@@ -50,11 +50,12 @@ The following conditions require new certification assets:
 ```bash
 pip3 install o-must-gather --user
 ```
-- Download the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) or another tool to pull from AWS S3
 
 ### Download Baseline CI results <a name="setup-download-baseline"></a>
 
-The Openshift provider certification tool is run periodically ([source code](https://github.com/openshift/release/blob/master/ci-operator/jobs/redhat-openshift-ecosystem/provider-certification-tool/redhat-openshift-ecosystem-provider-certification-tool-main-periodics.yaml)) in OpenShift CI using the latest stable release of OpenShift. These baseline results are stored long-term in an AWS S3 bucket (`s3://openshift-provider-certification/baseline-results`). These baseline results should be used as a reference when reviewing a partner's certification results.
+The Openshift provider certification tool is run periodically ([source code](https://github.com/openshift/release/blob/master/ci-operator/jobs/redhat-openshift-ecosystem/provider-certification-tool/redhat-openshift-ecosystem-provider-certification-tool-main-periodics.yaml)) in OpenShift CI using the latest stable release of OpenShift. 
+These baseline results are stored long-term in an AWS S3 bucket (`s3://openshift-provider-certification/baseline-results`). An HTML listing can be found here: https://openshift-provider-certification.s3.us-west-2.amazonaws.com/index.html.
+These baseline results should be used as a reference when reviewing a partner's certification results.
 
 You will need and AWS Access Key/ID for the `openshift-dev` AWS account in order to download from the S3 bucket.
 
@@ -64,16 +65,10 @@ $ omg get clusterversion
 NAME     VERSION  AVAILABLE  PROGRESSING  SINCE  STATUS
 version  4.11.13   True       False        11h    Cluster version is 4.11.13
 ```
-2. List all versions from the S3 bucket containing baseline certification results:
+2. Navigate to https://openshift-provider-certification.s3.us-west-2.amazonaws.com/index.html and find the latest results (by date) for the matching OpenShift version
+3. Download the *latest* test results for the version (bottom of list). Copy the results archive link from the webpage in previous step. 
 ```bash
-$ aws s3 ls s3://openshift-provider-certification/baseline-results/ | grep 4.11.13
-2022-11-24 17:38:30   69644276 4.11.13-20221125.tar.gz
-```
-3. Download the *latest* test results for the version (bottom of list):
-```bash
-$ aws s3 cp s3://openshift-provider-certification/baseline-results/4.11.13-20221125.tar.gz  .
-download: s3://openshift-provider-certification/baseline-results/4.11.13-20221125.tar.gz to ./4.11.13-20221125.tar.gz
-
+$ curl --output 4.11.13-20221125.tar.gz https://openshift-provider-certification.s3.us-west-2.amazonaws.com/baseline-results/4.11.13-20221125.tar.gz
 $ file 4.11.13-20221125.tar.gz 
 4.11.13-20221125.tar.gz: gzip compressed data, original size modulo 2^32 430269440
 ```

--- a/docs/support-guide.md
+++ b/docs/support-guide.md
@@ -5,7 +5,7 @@
     - [New Executions](#check-list-new-executions)
 - [Setting up the Review Environment](#setup)
     - [Install tools](#setup-install)
-    - [Download dependencies](#setup-download-dependencies)
+    - [Download dependencies](#setup-download-baseline)
     - [Download Partner Results](#setup-download-results)
 - [Review guide: exploring the failed tests](#review-process)
     - [Exploring the failures](#review-process-exploring)
@@ -43,21 +43,42 @@ The following conditions require new certification assets:
 
 ## Review Environment <a name="setup"></a>
 
-### Setting up local environment <a name="setup-install"></a>
+### Install Tools <a name="setup-install"></a>
 
 - Download the [openshift-provider-cert](./user.md#install): OpenShift Provider Certification tool
 - Download the [`omg`](https://github.com/kxr/o-must-gather): tool to analyse Must-gather archive
-
 ```bash
 pip3 install o-must-gather --user
 ```
+- Download the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) or another tool to pull from AWS S3
 
-### Download dependencies <a name="setup-download-dependencies"></a>
+### Download Baseline CI results <a name="setup-download-baseline"></a>
 
-- Download the Baseline results from the <TBD>`quay.io/ocp-cert/baseline-results`
+The Openshift provider certification tool is run periodically ([source code](https://github.com/openshift/release/blob/master/ci-operator/jobs/redhat-openshift-ecosystem/provider-certification-tool/redhat-openshift-ecosystem-provider-certification-tool-main-periodics.yaml)) in OpenShift CI using the latest stable release of OpenShift. These baseline results are stored long-term in an AWS S3 bucket (`s3://openshift-provider-certification/baseline-results`). These baseline results should be used as a reference when reviewing a partner's certification results.
 
-> TODO: add the steps to pull and extract the results from the baseline repository (S3)
+You will need and AWS Access Key/ID for the `openshift-dev` AWS account in order to download from the S3 bucket.
 
+1. Identify cluster version in the partner's must gather:
+```bash
+$ omg get clusterversion
+NAME     VERSION  AVAILABLE  PROGRESSING  SINCE  STATUS
+version  4.11.13   True       False        11h    Cluster version is 4.11.13
+```
+2. List all versions from the S3 bucket containing baseline certification results:
+```bash
+$ aws s3 ls s3://openshift-provider-certification/baseline-results/ | grep 4.11.13
+2022-11-24 17:38:30   69644276 4.11.13-20221125.tar.gz
+```
+3. Download the *latest* test results for the version (bottom of list):
+```bash
+$ aws s3 cp s3://openshift-provider-certification/baseline-results/4.11.13-20221125.tar.gz  .
+download: s3://openshift-provider-certification/baseline-results/4.11.13-20221125.tar.gz to ./4.11.13-20221125.tar.gz
+
+$ file 4.11.13-20221125.tar.gz 
+4.11.13-20221125.tar.gz: gzip compressed data, original size modulo 2^32 430269440
+```
+
+4. Proceed with comparing baseline results with actual provider results.
 - Download the suite test list for the version used by the partner
 
 ```bash

--- a/docs/support-guide.md
+++ b/docs/support-guide.md
@@ -57,8 +57,6 @@ The Openshift provider certification tool is run periodically ([source code](htt
 These baseline results are stored long-term in an AWS S3 bucket (`s3://openshift-provider-certification/baseline-results`). An HTML listing can be found here: https://openshift-provider-certification.s3.us-west-2.amazonaws.com/index.html.
 These baseline results should be used as a reference when reviewing a partner's certification results.
 
-You will need and AWS Access Key/ID for the `openshift-dev` AWS account in order to download from the S3 bucket.
-
 1. Identify cluster version in the partner's must gather:
 ```bash
 $ omg get clusterversion

--- a/docs/user.md
+++ b/docs/user.md
@@ -45,7 +45,7 @@ A Red Hat OpenShift 4 cluster must be [installed](https://docs.openshift.com/con
 
 ### Standard Environment <a name="standard-env"></a>
 
-A dedicated compute node should be used to avoid disruption of the test scheduler. Otherwise, the concurrency between resources scheduled on the cluster, e2e-test manager (aka openshift-tests-plugin), and other stacks like monitoring can disrupt the test environment, leading to unexpected results, like the eviction of plugins or certification server (sonobuoy pod).
+A dedicated compute node should be used to avoid disruption of the test scheduler. Otherwise, the concurrency between resources scheduled on the cluster, e2e-test manager (aka openshift-tests-plugin), and other stacks like monitoring can disrupt the test environment, leading to unexpected results, like the eviction of plugins or aggregator server (`sonobuoy` pod).
 
 The dedicated node environment cluster size can be adjusted to match the table below. Note the differences in the `Dedicated Test` machine:
 

--- a/docs/user.md
+++ b/docs/user.md
@@ -12,7 +12,6 @@ Table Of Contents:
 - [Prerequisites](#prerequisites)
     - [Standard Environment](#standard-env)
         - [Environment Setup](#standard-env-setup)
-    - [Development Environment](#development-env)
     - [Privilege Requirements](#priv-requirements)
 - [Install](#install)
     - [Prebuilt Binary](#install-bin)
@@ -89,16 +88,6 @@ Here is a `MachineSet` YAML snippet on how to configure the label and taint as w
         - key: node-role.kubernetes.io/tests
           effect: NoSchedule
 ```
-
-### Development Environment <a name="development-env"></a>
-
-If you wish to run the certification tool in a smaller OpenShift environment for test or development purposes, you may run it like below, disabling dedicated mode:
-
-```shell
-openshift-provider-cert run --dedicated false
-```
-
-Keep in mind that you may run into resource constraint issues using fewer resources than defined in the standard method above. 
 
 ### Privilege Requirements <a name="priv-requirements"></a>
 

--- a/docs/user.md
+++ b/docs/user.md
@@ -11,8 +11,8 @@ Table Of Contents:
 - [Process](#process)
 - [Prerequisites](#prerequisites)
     - [Standard Environment](#standard-env)
-    - [Dedicated test Environment](#dedicated-env)
-        - [Environment Setup](#dedicated-env-setup)
+        - [Environment Setup](#standard-env-setup)
+    - [Development Environment](#development-env)
     - [Privilege Requirements](#priv-requirements)
 - [Install](#install)
     - [Prebuilt Binary](#install-bin)
@@ -45,22 +45,7 @@ A Red Hat OpenShift 4 cluster must be [installed](https://docs.openshift.com/con
 
 ### Standard Environment <a name="standard-env"></a>
 
-A standard machine layout can be used for certification. If you run into issues with pod disruption (eviction, OOM, frequent crashes, etc) then you may want to consider the Dedicated Test Environment configuration further below. Below is a table of the minimum resource requirements for the OpenShift cluster under test:
-
-| Machine       | Count | CPU | RAM (GB) | Storage (GB) |
-| ------------- | ----- | --- | -------- | ------------ |
-| Bootstrap     | 1     | 4   | 16       | 100          |
-| Control Plane | 3     | 4   | 16       | 100          |
-| Compute       | 3     | 4   | 16       | 100          |
-
-
-*Note: These requirements are higher than the [minimum requirements](https://docs.openshift.com/container-platform/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-minimum-resource-requirements_installing-bare-metal) in OpenShift product documentation due to the resource demand of the certification tests.*
-
-### Dedicated Node for Test Environment <a name="dedicated-env"></a>
-
-If your compute nodes are at or below minimum requirements, it is recommended to run the certification environment on one dedicated node to avoid disruption of the test scheduler. Otherwise, the concurrency between resources scheduled on the cluster, e2e-test manager (aka openshift-tests-plugin), and other stacks like monitoring can disrupt the test environment, leading to unexpected results, like the eviction of plugins or certification server (sonobuoy pod).
-
-See the troubleshooting section on ways to identify you might need to use a dedicated node test environment below.
+A dedicated compute node should be used to avoid disruption of the test scheduler. Otherwise, the concurrency between resources scheduled on the cluster, e2e-test manager (aka openshift-tests-plugin), and other stacks like monitoring can disrupt the test environment, leading to unexpected results, like the eviction of plugins or certification server (sonobuoy pod).
 
 The dedicated node environment cluster size can be adjusted to match the table below. Note the differences in the `Dedicated Test` machine:
 
@@ -71,7 +56,9 @@ The dedicated node environment cluster size can be adjusted to match the table b
 | Compute       | 3     | 4   | 16       | 100          |
 | Dedicated Test| 1     | 4   | 8        | 100          |
 
-#### Environment Setup <a name="dedicated-env-setup"></a>
+*Note: These requirements are higher than the [minimum requirements](https://docs.openshift.com/container-platform/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-minimum-resource-requirements_installing-bare-metal) in OpenShift product documentation due to the resource demand of the certification tests.*
+
+#### Environment Setup <a name="standard-env-setup"></a>
 
 1. Choose one node with at least 8GiB of RAM and 4 vCPU
 2. Label node with `node-role.kubernetes.io/tests=""` (certification-related pods will schedule to dedicated node)
@@ -81,14 +68,14 @@ The dedicated node environment cluster size can be adjusted to match the table b
 
 There are two options to accomplish this type of setup:
 
-##### Option A: Command Line 
+##### Option A: Command Line
 
 ```shell
 oc label node <node_name> node-role.kubernetes.io/tests=""
 oc adm taint node <node_name> node-role.kubernetes.io/tests="":NoSchedule
 ```
 
-##### Option B: Machine Set 
+##### Option B: Machine Set
 
 If you have support for OpenShift's Machine API then you can create a new `MachineSet` to configure the labels and taints. See [OpenShift documentation](https://docs.openshift.com/container-platform/latest/machine_management/creating-infrastructure-machinesets.html#binding-infra-node-workloads-using-taints-tolerations_creating-infrastructure-machinesets) on how to configure a new `MachineSet`. Note that at the time of certification testing, OpenShift's product documentation may not mention your infrastructure provider yet!
 
@@ -103,6 +90,15 @@ Here is a `MachineSet` YAML snippet on how to configure the label and taint as w
           effect: NoSchedule
 ```
 
+### Development Environment <a name="development-env"></a>
+
+If you wish to run the certification tool in a smaller OpenShift environment for test or development purposes, you may run it like below, disabling dedicated mode:
+
+```shell
+openshift-provider-cert run --dedicated false
+```
+
+Keep in mind that you may run into resource constraint issues using fewer resources than defined in the standard method above. 
 
 ### Privilege Requirements <a name="priv-requirements"></a>
 
@@ -204,7 +200,7 @@ You will need to destroy the OpenShift cluster under test separately.
 
 Check also the documents below that might help while investigating the results and failures of the Provider Certification process:
 
-- [Troubleshooring Guide](./troubleshooting-guide.md)
+- [Troubleshooting Guide](./troubleshooting-guide.md)
 - [Installation Review](./user-installation-review.md)
 
 ## Feedback <a name="feedback"></a>

--- a/docs/user.md
+++ b/docs/user.md
@@ -56,7 +56,7 @@ The dedicated node environment cluster size can be adjusted to match the table b
 | Compute       | 3     | 4   | 16       | 100          |
 | Dedicated Test| 1     | 4   | 8        | 100          |
 
-*Note: These requirements are higher than the [minimum requirements](https://docs.openshift.com/container-platform/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-minimum-resource-requirements_installing-bare-metal) in OpenShift product documentation due to the resource demand of the certification tests.*
+*Note: These requirements are higher than the [minimum requirements](https://docs.openshift.com/container-platform/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-minimum-resource-requirements_installing-bare-metal) for a regular cluster (non-certification) in OpenShift product documentation due to the resource demand of the certification environment.*
 
 #### Environment Setup <a name="standard-env-setup"></a>
 


### PR DESCRIPTION
This PR has 2 separate items:

- A dedicated environment setup is now considered standard. Development or test environment setup will be non-dedicated `--dedicated=false`.
- How to download baseline results from S3 bucket