### PR TITLE
devel/v0.5: tracking improvements in the review process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,11 @@ cross-build-darwin-arm64:
 linux-amd64-container: linux-amd64
 	podman build -t $(IMG):latest -f hack/Containerfile --build-arg=RELEASE_TAG=$(RELEASE_TAG) .
 
+# Publish devel binaries (non-official). Must be used only for troubleshooting in development/support.
+.PHONY: publish-amd64-devel
+publish-amd64-devel: linux-amd64
+	aws s3 cp ./opct-linux-amd64 s3://openshift-provider-certification/bin/opct-linux-amd64-devel
+
 .PHONY: test
 test:
 	go test ./...

--- a/docs/support-guide.md
+++ b/docs/support-guide.md
@@ -63,7 +63,7 @@ $ omg get clusterversion
 NAME     VERSION  AVAILABLE  PROGRESSING  SINCE  STATUS
 version  4.11.13   True       False        11h    Cluster version is 4.11.13
 ```
-2. Navigate to https://openshift-provider-certification.s3.us-west-2.amazonaws.com/index.html and find the latest results (by date) for the matching OpenShift version
+2. Navigate to the [CI results](https://openshift-provider-certification.s3.us-west-2.amazonaws.com/index.html) and find the latest results (by date) for the matching OpenShift version
 3. Download the *latest* test results for the version (bottom of list). Copy the results archive link from the webpage in previous step. 
 ```bash
 $ curl --output 4.11.13-20221125.tar.gz https://openshift-provider-certification.s3.us-west-2.amazonaws.com/baseline-results/4.11.13-20221125.tar.gz
@@ -293,22 +293,25 @@ Additional items to review:
 The validation process (when applyging for the Partner Support Case) requires a successful y-stream upgrade (e.g. upgrade 4.11.17 to 4.12.0).
 Upgrade review should only proceed if there is reasonably high confidence in passing and not if there are still significant issues in passing the review process above. 
 
-> TODO: Rework this documentation after the automated upgrade procedure is merged in https://github.com/redhat-openshift-ecosystem/provider-certification-tool/pull/33
+> TODO: Review this documentation after the automated upgrade procedure is merged in https://github.com/redhat-openshift-ecosystem/provider-certification-tool/pull/33
 
 Once prepared to review an upgrade, this is the recommended procedure:
 
 1. Cloud provider to install _new_ cluster as the version previously reviewed in the process above
 2. Initiate upgrade to next Y-stream version per OpenShift documentation 
 3. Cloud provider to make note of the following during upgrade:
+
    - Any manual intervention required during upgrade
    - Time taken to complete upgrade 
    - Any components left in failed state or not upgraded (e.g. web console offline, inaccessible API)
+
 4. Must gather after successful or failed upgrade
 
 If there was manual intervention required during the upgrade this will require judgement of the OpenShift engineer reviewing the upgrade. 
 Some questions to ask are:
 
 Is the manual intervention...
+
 - Working around a known bug in OpenShift?
 - Working around a potential new bug in OpenShift?
 - Working around a known issue in OpenShift but not considered a bug and has documentation?
@@ -322,17 +325,17 @@ First, check the `ClusterVersion` resource to verify the upgrade was successful:
 
 Using the `omg` tool:
 
-```
+```bash
 omg get clusterversion
 ```
 
 Next, check each Cluster Operator and Node was upgraded and in a working/ready state:
 
-```
+```bash
 omg get clusteroperators
 omg get nodes
 ```
 
-Review the Must Gather using the Insights tool as mentioned (here)[#review-process-guidelines].
+Review the Must Gather using the Insights tool as mentioned [here](#review-process-guidelines).
 
 If there are any issues found in the steps above, the upgrade should be performed again (on a _new_ cluster) and upgrade review process restarted.

--- a/docs/troubleshooting-guide.md
+++ b/docs/troubleshooting-guide.md
@@ -42,6 +42,7 @@ results/
 ├── servergroups.json
 └── serverversion.json
 ```
+
 - `hosts` provides the kubelet configuration and health check for each node on the cluster
 - `meta` has the metadata collected from the cluster and validation environment
 - `plugins` has the plugins definitions and results

--- a/internal/pkg/sippy/sippy.go
+++ b/internal/pkg/sippy/sippy.go
@@ -55,17 +55,19 @@ type SippyTestsRequestOutput []SippyTestsResponse
 
 // SippyAPI is the Sippy API structure holding the API client
 type SippyAPI struct {
-	client *http.Client
+	client     *http.Client
+	ocpVersion string
 }
 
 // NewSippyAPI creates a new API setting the http attributes to improve the connection reuse.
-func NewSippyAPI() *SippyAPI {
+func NewSippyAPI(ocpVersion string) *SippyAPI {
 	t := http.DefaultTransport.(*http.Transport).Clone()
 	t.MaxIdleConns = defaultMaxIdleConns
 	t.MaxConnsPerHost = defaultMaxConnsPerHost
 	t.MaxIdleConnsPerHost = defaultMaxIddleConnsPerHost
 
 	return &SippyAPI{
+		ocpVersion: ocpVersion,
 		client: &http.Client{
 			Timeout:   defaultConnTimeoutSec * time.Second,
 			Transport: t,
@@ -75,14 +77,14 @@ func NewSippyAPI() *SippyAPI {
 
 // QueryTests receive a input with attributes to query the results of a single test
 // by name on the CI, returning the list with result items.
-func (a *SippyAPI) QueryTests(r *SippyTestsRequestInput) (*SippyTestsRequestOutput, error) {
+func (a *SippyAPI) QueryTests(in *SippyTestsRequestInput) (*SippyTestsRequestOutput, error) {
 
 	filter := SippyTestsRequestFilter{
 		Items: []SippyTestsRequestFilterItems{
 			{
 				ColumnField:   "name",
 				OperatorValue: "equals",
-				Value:         r.TestName,
+				Value:         in.TestName,
 			},
 		},
 	}
@@ -98,7 +100,7 @@ func (a *SippyAPI) QueryTests(r *SippyTestsRequestInput) (*SippyTestsRequestOutp
 	}
 
 	params := url.Values{}
-	params.Add("release", "4.11")
+	params.Add("release", a.ocpVersion)
 	params.Add("filter", string(b))
 
 	baseUrl.RawQuery = params.Encode()

--- a/internal/pkg/summary/opct.go
+++ b/internal/pkg/summary/opct.go
@@ -35,7 +35,7 @@ type OPCTPluginSummary struct {
 	// FailedFilterBaseline is the list of failures (A) excluding the baseline(B): A EXCLUDE B
 	FailedFilterBaseline []string
 	// FailedFilteFlaky is the list of failures with no Flakes on OpenShift CI
-	FailedFilterFlaky []string
+	FailedFilterNotFlake []string
 }
 
 type PluginFailedItem struct {

--- a/internal/pkg/summary/openshift.go
+++ b/internal/pkg/summary/openshift.go
@@ -2,11 +2,13 @@ package summary
 
 import (
 	"fmt"
+	"regexp"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/pkg/errors"
 )
 
+// OpenShiftSummary holds the data collected from artifacts related to OpenShift objects.
 type OpenShiftSummary struct {
 	Infrastructure   *configv1.Infrastructure
 	ClusterVersion   *configv1.ClusterVersion
@@ -75,6 +77,16 @@ func (os *OpenShiftSummary) GetClusterVersion() (*SummaryClusterVersionOutput, e
 		}
 	}
 	return &resp, nil
+}
+
+func (os *OpenShiftSummary) GetClusterVersionXY() (string, error) {
+	out, err := os.GetClusterVersion()
+	if err != nil {
+		return "", err
+	}
+	re := regexp.MustCompile(`^(\d+.\d+)`)
+	match := re.FindStringSubmatch(out.DesiredVersion)
+	return match[1], nil
 }
 
 func (os *OpenShiftSummary) SetClusterOperators(cr *configv1.ClusterOperatorList) error {

--- a/pkg/report/tags.go
+++ b/pkg/report/tags.go
@@ -1,0 +1,91 @@
+package report
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+)
+
+const tagRegex = `^\[([a-zA-Z0-9-]*)\]`
+
+// SortedData stores the key/value to be sorted.
+type SortedData struct {
+	Key   string
+	Value int
+}
+
+// SortedList stores the list of key/value map, implementing interfaces
+// to sort/rank a map strings with integers as values.
+type SortedList []SortedData
+
+func (p SortedList) Len() int           { return len(p) }
+func (p SortedList) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+func (p SortedList) Less(i, j int) bool { return p[i].Value < p[j].Value }
+
+// TestTags stores the test tags map with it's counter.
+// The test tag is the work extracted from the first bracket from a test name.
+// Example test name: '[sig-provider] test name' the 'sig-provider' is the tag.
+type TestTags map[string]int
+
+// NewTestTagsEmpty creates the TestTags with a specific size, to be populated later.
+func NewTestTagsEmpty(size int) TestTags {
+	tt := make(TestTags, size)
+	tt["total"] = 0
+	return tt
+}
+
+// NewTestTags creates the TestTags populating the tag values and counters.
+func NewTestTags(tests []*string) TestTags {
+	tt := make(TestTags, len(tests))
+	tt["total"] = 0
+	tt.addBatch(tests)
+	return tt
+}
+
+// Add extracts tags from test name, store, and increment the counter.
+func (tt TestTags) Add(test *string) {
+	reT := regexp.MustCompile(tagRegex)
+	match := reT.FindStringSubmatch(*test)
+	if len(match) > 0 {
+		if _, ok := tt[match[1]]; !ok {
+			tt[match[1]] = 1
+		} else {
+			tt[match[1]] += 1
+		}
+	}
+	tt["total"] += 1
+}
+
+// AddBatch receive a list of test name (string slice) and stores it.
+func (tt TestTags) addBatch(kn []*string) {
+	for _, test := range kn {
+		tt.Add(test)
+
+	}
+}
+
+// SortRev creates a rank of tags.
+func (tt TestTags) sortRev() []SortedData {
+	tags := make(SortedList, len(tt))
+	i := 0
+	for k, v := range tt {
+		tags[i] = SortedData{k, v}
+		i++
+	}
+	sort.Sort(sort.Reverse(tags))
+	return tags
+}
+
+// ShowSorted return an string with the rank of tags.
+func (tt TestTags) ShowSorted() string {
+	tags := tt.sortRev()
+	msg := ""
+	for _, k := range tags {
+		if k.Key == "total" {
+			msg = fmt.Sprintf("[%v=%v]", k.Key, k.Value)
+			continue
+		}
+		msg = fmt.Sprintf("%s [%v=%s]", msg, k.Key, calcPercStr(int64(k.Value), int64(tt["total"])))
+	}
+	return msg
+}

--- a/pkg/report/tags_test.go
+++ b/pkg/report/tags_test.go
@@ -1,0 +1,42 @@
+package report
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func validTests(testDesc *string) []*string {
+	tests := []*string{}
+	prefix := "tag"
+	for i := 1; i <= 5; i++ {
+		test := fmt.Sprintf("[%s-%d] %s ID %d", prefix, i, *testDesc, i)
+		tests = append(tests, &test)
+	}
+	return tests
+}
+
+func TestShowSorted(t *testing.T) {
+	desc := "TestShowSorted"
+	cases := []struct {
+		name  string
+		tests []*string
+		want  string
+	}{
+		{
+			name:  "empty",
+			tests: validTests(&desc),
+			want:  "[total=5] [tag-1=1 (20.00%)] [tag-2=1 (20.00%)] [tag-3=1 (20.00%)] [tag-4=1 (20.00%)] [tag-5=1 (20.00%)]",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// fmt.Printf("%v\n", tc.tests)
+			testTags := NewTestTags(tc.tests)
+			msg := testTags.ShowSorted()
+			assert.Equal(t, tc.want, msg, "unexpected ,essage")
+		})
+	}
+}


### PR DESCRIPTION
TODO: need to isolate improvements into smaller changes

## Bug fixes

- [ ] `report`: Flake tests now is querying to correct OCP version on Sippy API
- [ ] `report`: Flake report prevents duplicated tests from immediate action
- [ ] `report`: Flake report does not show items reporting than 5% of flake count in OCP CI (by Sippy)
~~~
Flakes	Perc		 TestName
288	23.782%		[bz-DNS][invariant] alert/KubePodNotReady should not be at or above pending in ns/openshift-dns
967	79.851%		[bz-OLM][invariant] alert/KubePodNotReady should not be at or above pending in ns/openshift-marketplace
[...]
~~~
- [ ] Filter pipeline is not breaking when the suite list is empty (collected by artifact collector plugin). Example:
~~~
 Total tests by conformance suites:
 - kubernetes/conformance: 0 
 - openshift/conformance: 0 
~~~

## Improvements

- [ ] Documentation updates for review guides
- [ ] `report`: now the counters are displaying the percentage of it (when comparing with the total). So it can quickly have one idea of failures - in general, we expect lower than 1% of failures in an regular installation for OpenShift Conformance
~~~
 Result Summary by conformance plugins:
 - 10-openshift-kube-conformance:
   - Status: failed
   - Total: 724
   - Passed: 695 (95.99%)
   - Failed: 29 (4.01%)
   - Timeout: 0 (0.00%)
   - Skipped: 0 (0.00%)
   - Failed (without filters) : 29 (4.01%)
   - Failed (Filter SuiteOnly): 0 (0.00%)
   - Failed (Filter CI Flakes): 0 (0.00%)
 - 20-openshift-conformance-validated:
   - Status: failed
   - Total: 3810
   - Passed: 1681 (44.12%)
   - Failed: 55 (1.44%)
   - Timeout: 0 (0.00%)
   - Skipped: 2074 (54.44%)
   - Failed (without filters) : 55 (1.44%)
   - Failed (Filter SuiteOnly): 21 (0.55%)
   - Failed (Filter CI Flakes): 14 (0.37%)
~~~
- [ ] `report`: a headline with grouped (by test tags) occurrences is displayed before each failed list for both conformance plugins
~~~
 => 10-openshift-kube-conformance: (36 failures, 28 flakes)
 --> Failed tests to Review (without flakes) - Immediate action:
[total=8] [sig-apps=2 (25.00%)] [sig-cli=2 (25.00%)] [sig-node=2 (25.00%)] [sig-api-machinery=1 (12.50%)] 
[sig-arch=1 (12.50%)]
[...]
--> Failed flake tests - Statistic from OpenShift CI
[total=28] [sig-api-machinery=12 (42.86%)] [sig-node=4 (14.29%)] [sig-network-edge=4 (14.29%)] [sig-trt=3 (10.71%)] 
[sig-architecture=3 (10.71%)] [bz-OLM=1 (3.57%)] [sig-arch=1 (3.57%)]
[...]
 => 20-openshift-conformance-validated: (102 failures, 43 flakes)

 --> Failed tests to Review (without flakes) - Immediate action:
[total=59] [sig-builds=15 (25.42%)] [sig-apps=10 (16.95%)] [sig-cli=7 (11.86%)] [sig-imageregistry=7 (11.86%)] 
[sig-auth=6 (10.17%)] [sig-network=6 (10.17%)] [sig-arch=2 (3.39%)] [sig-devex=1 (1.69%)] 
[sig-instrumentation=1 (1.69%)] [sig-api-machinery=1 (1.69%)] [sig-scheduling=1 (1.69%)] [sig-node=1 (1.69%)] 
[bz-Unknown=1 (1.69%)]
[...]
 --> Failed flake tests - Statistic from OpenShift CI
[total=43] [sig-api-machinery=12 (27.91%)] [sig-node=6 (13.95%)] [sig-arch=5 (11.63%)] [sig-network-edge=4 (9.30%)] 
[sig-trt=3 (6.98%)] [sig-instrumentation=3 (6.98%)] [sig-network=2 (4.65%)] [sig-architecture=2 (4.65%)] 
[sig-autoscaling=1 (2.33%)] [bz-OLM=1 (2.33%)] [bz-Routing=1 (2.33%)] [bz-Unknown=1 (2.33%)] 
[bz-kube-apiserver=1 (2.33%)] [bz-DNS=1 (2.33%)]
[...]
~~~

- [ ] The final results binary message (after filters) has been removed. This field is temporarily removed to prevent mistakes when some issues happen in the filter pipeline, and also to focus on the failures, not on the binary value, considering that the goal is to zero-ed the failed tests.
- [ ] `run --watch --watch-interval`: Status can set custom watch interval to decrease the number of logs in CI
- [ ] `report --diff`: created as alias of `--baseline`, setting it as deprecated
- [ ] `report --save-to`: now the HTML report is saved with hyperlinks to the logs instead of an excel file. [Preview](https://openshift-provider-certification.s3.us-west-2.amazonaws.com/tmp/report.html#)
- [ ] `report html`: rank by error count


### Plugin Runtime

- [ ] `status`: replace the message `waiting for post-processor...` to `complete` when the pod finished.

~~~
# from
Sat, 15 Jul 2023 00:39:31 -03> Global Status: running
JOB_NAME                           | STATUS     | RESULTS    | PROGRESS                  | MESSAGE                                           
05-openshift-cluster-upgrade       | complete   |            | 0/0 (0 failures)          | waiting for post-processor...                     
10-openshift-kube-conformance      | complete   |            | 5/377 (0 failures)        | waiting for post-processor...                     
20-openshift-conformance-validated | running    |            | 0/3684 (0 failures)       | status=waiting-for=10-openshift-kube-conformance=(0/-372/0)=[3/1080]
99-openshift-artifacts-collector   | running    |            | 0/0 (0 failures)          | status=blocked-by=20-openshift-conformance-validated=(0/-3684/0)=[0/1080]

# to
Sat, 15 Jul 2023 01:17:58 -03> Global Status: running
JOB_NAME                           | STATUS     | RESULTS    | PROGRESS                  | MESSAGE                                           
05-openshift-cluster-upgrade       | complete   |            | 0/0 (0 failures)          | complete                                          
10-openshift-kube-conformance      | complete   |            | 5/377 (0 failures)        | complete                                          
20-openshift-conformance-validated | running    |            | 5/3684 (0 failures)       | status=running=T/C/P/F/S=3684/5/3/0/2             
99-openshift-artifacts-collector   | running    |            | 0/0 (0 failures)          | status=waiting-for=20-openshift-conformance-validated=(0/-3679/0)=[8/1080]

~~~